### PR TITLE
Got mockReactComponent to handle wrapped components

### DIFF
--- a/lib/ExpandedTestUtils.js
+++ b/lib/ExpandedTestUtils.js
@@ -156,7 +156,10 @@ module.exports = {
             //an empty div and overwrite it's options with what was provided or an empty object
             var displayName;
             if(type){
-                displayName = type.displayName || type.name;
+                // If the component is a wrapped component such as Connect(SomeComponent) or InjectIntl(SomeComponent), this would
+                // let you use mockReactComponent('SomeComponent') instead
+                var wrappedType = type.WrappedComponent && (type.WrappedComponent.displayName || type.WrappedComponent.name);
+                displayName = wrappedType || type.displayName || type.name;
             }
             if(displayName && componentList.indexOf(displayName) > -1){
                 var mock = React.createClass({


### PR DESCRIPTION
It's kinda frustrating to have to use `mockReactComponent('InjectIntl(SomeComponent)')` instead of `mockReactComponent('SomeComponent')` when trying to mock a component that uses `react-intl`.

This  would check if the component has a wrapped component (like redux connect) so that you can set up your mocks easier.